### PR TITLE
Make it easier to give custom args to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ EXPOSE 9000
 
 ENV PYTHONPATH="/opt"
 
-ENTRYPOINT ["python", "-u", "/opt/aws_prometheus_exporter", "-p", "9000", "-f", "/mnt/metrics.yaml", "-s", "300"]
+ENTRYPOINT [ "python", "-u", "/opt/aws_prometheus_exporter", "-p", "9000" ]
+CMD [ "-f", "/mnt/metrics.yaml", "-s", "300" ]


### PR DESCRIPTION
With this, one can run the image with different command line arguments easily:

```
docker run -p9000:9000 -v $(pwd)/example.yaml:/mnt/metrics.yaml 17d0c23da2c3 -f /mnt/metrics.yaml -s 3000
```